### PR TITLE
Add GeoJSON as import source

### DIFF
--- a/widgets/import_data/import_data.py
+++ b/widgets/import_data/import_data.py
@@ -15,6 +15,7 @@ import PagLuxembourg.main
 
 from import_gml import ImportGML
 from import_shp import ImportSHP
+from import_geojson import ImportGeoJSON
 from import_dxf import ImportDXF
 
 class ImportData(object):
@@ -40,7 +41,7 @@ class ImportData(object):
         dialog = QFileDialog()
         dialog.setFileMode(QFileDialog.ExistingFile)
         dialog.setOption(QFileDialog.ReadOnly)
-        dialog.setNameFilter('Vector file (*.gml *.shp *.dxf)');
+        dialog.setNameFilter('Vector file (*.gml *.shp *.geojson *.dxf)');
         dialog.setWindowTitle(QCoreApplication.translate('ImportData','Select the file to import'))
         dialog.setSizeGripEnabled(False)
         result = dialog.exec_()
@@ -57,6 +58,7 @@ class ImportData(object):
         importers = {
                     'gml':ImportGML,
                     'shp':ImportSHP,
+                    'geojson': ImportGeoJSON,
                     'dxf':ImportDXF
                     }
         

--- a/widgets/import_data/import_geojson.py
+++ b/widgets/import_data/import_geojson.py
@@ -1,0 +1,30 @@
+'''
+Created on 05 nov. 2015
+
+@author: arxit
+'''
+
+from import_shp_dialog import ImportShpDialog
+
+class ImportGeoJSON(object):
+    '''
+    Main class for the import data widget
+    '''
+    
+    def __init__(self, filename):
+        '''
+        Constructor
+        
+        :param filename: The GeoJSON filename
+        :type filename: str, QString
+        '''
+        self.filename = filename
+    
+    def runImport(self):
+        '''
+        Import a GeoJSON file
+        '''
+        
+        self.dlg = ImportShpDialog(self.filename)
+        if self.dlg.valid:
+            self.dlg.show()


### PR DESCRIPTION
I've added GeoJSON as a available input source for importing data. The tool has this nice column matching function which automatically selects matching columns from the import source to the database source. Unfortunately this does not work for Shapefiles because there is this 10 character attribute column name restriction for shapefiles and the column names therefore do not match very often.
By using GeoJSON as a workaround I can make the column matching work nicely since there's no such column name restriction as with the shapefile.

If you think this is a useful contribution, you're more than welcome to accept my proposal :-)